### PR TITLE
use React.Proptypes in the Gravatar component

### DIFF
--- a/subjects/03-components/lecture.js
+++ b/subjects/03-components/lecture.js
@@ -150,7 +150,7 @@ updateThePage()
 //
 //const Gravatar = React.createClass({
 //  propTypes: {
-//    email: string.isRequired
+//    email: React.PropTypes.string.isRequired
 //  },
 //  render() {
 //    const src = `${GravatarURL}/${md5(this.props.email)}?s=40`
@@ -160,7 +160,7 @@ updateThePage()
 //
 //const App = React.createClass({
 //  propTypes: {
-//    users: array
+//    users: React.PropTypes.array
 //  },
 //  render() {
 //    return (


### PR DESCRIPTION
Console was returning a `Uncaught ReferenceError: string is not defined(anonymous function) @ lecture.js:153` error  when trying to run the Gravatar example

could also use `const { string, array } = React.PropTypes;` I don't know what you guys prefer